### PR TITLE
Feature/add init command

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,22 @@ Both of these options can be combined to a create a more complete command:
 
 `gh-templating use bugfix/stop-app-from-exploding other/version-control/pull-requests/templates`
 
+## Init
+
+This package can also help you get started on your magical PR templating journey! To get the ball rolling, run the init command in your project:
+
+`gh-templating init`
+
+With no arguments provided, gh-templating will prompt you for both the path to the directory and the directory name. Once you pass those in, a new directory will be created where you can begin creating your PR templates.
+
+You can skip these prompts by providing both arguments at the start:
+
+`gh-templating init .github templates`
+
+This package also provides defaults. If you leave each prompt blank, gh-templating will create a default directory called templates in your .github folder. Alternatively, you can pass the optional argument `-y` to short-circuit and immediately create the default directory.
+
+`gh-templating init -y`
+
 <br>
 <hr>
 <br>

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This tool finds your PR templates, prompts a selection menu, remembers your sele
 1. [Prerequisites](#prerequisites)
 2. [Installation](#installation)
 3. [Use](#use)
+4. [Init](#init)
 
 ## Prerequisites
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 #! /usr/bin/env node
-import { use } from "./src/index.mjs";
+import { use, init } from "./src/index.mjs";
 import { Command } from "commander";
 
 const program = new Command();
@@ -10,5 +10,12 @@ program
     .argument("[path]", "Path to templates directory - string - optional")
     .argument("[title]", "Title of your new PR - string - optional")
     .action((path, title) => use(path, title));
+
+program
+    .command("init")
+    .description("Initialize a directory for your templates")
+    .argument("[path]", "Path to your new directory - string - optional")
+    .argument("[dirName]", "Name of your new directory - string - optional")
+    .action((path, dirName) => init(path, dirName));
 
 program.parse(process.argv);

--- a/index.js
+++ b/index.js
@@ -16,6 +16,10 @@ program
     .description("Initialize a directory for your templates")
     .argument("[path]", "Path to your new directory - string - optional")
     .argument("[dirName]", "Name of your new directory - string - optional")
-    .action((path, dirName) => init(path, dirName));
+    .option(
+        "-y, --yes",
+        "Skip prompts and arguments and immediately create the default directory - boolean - optional"
+    )
+    .action((path, dirName, { yes }) => init(path, dirName, yes));
 
 program.parse(process.argv);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gh-templating",
-    "version": "1.3.1",
+    "version": "1.4.0",
     "description": "",
     "main": "index.js",
     "bin": {

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1,1 +1,2 @@
 export * from "./use.mjs";
+export * from "./init.mjs";

--- a/src/init.mjs
+++ b/src/init.mjs
@@ -1,0 +1,70 @@
+import inquirer from "inquirer";
+import fs from "fs";
+import path from "path";
+
+export const init = async (pathToTemplates, directoryName) => {
+    // TODO: foolproof/insulate
+    // mkdirAsync, chain?
+    let path = pathToTemplates;
+    let dirName = directoryName;
+
+    if (!pathToTemplates && !directoryName) {
+        const { path, dirName } = await resolveWithoutArgs();
+
+        fs.mkdirSync(path);
+        fs.mkdirSync(`${path}/${dirName}`);
+        return;
+    }
+
+    if (!pathToTemplates) {
+        path = await promptUserForPath();
+    }
+
+    if (!directoryName) {
+        dirName = await promptUserForDirName();
+    }
+
+    fs.mkdirSync(path);
+    fs.mkdirSync(`${path}/${dirName}`);
+};
+
+const resolveWithoutArgs = async () => {
+    const path = await promptUserForPath();
+    const dirName = await promptUserForDirName();
+
+    return { path, dirName };
+};
+
+const promptUserForPath = async () => {
+    return inquirer
+        .prompt([
+            {
+                type: "input",
+                name: "Path to new directory",
+                message: "Where would you like to store your templates?",
+            },
+        ])
+        .then((answers) => answers["Path to new directory"])
+        .catch((error) => {
+            console.error(
+                `Inquirer error: something went wrong processing your answer: ${error}`
+            );
+        });
+};
+
+const promptUserForDirName = async () => {
+    return inquirer
+        .prompt([
+            {
+                type: "input",
+                name: "Template directory name",
+                message: "What would you like to call your new directory?",
+            },
+        ])
+        .then((answers) => answers["Template directory name"])
+        .catch((error) => {
+            console.error(
+                `Inquirer error: something went wrong processing your answer: ${error}`
+            );
+        });
+};


### PR DESCRIPTION
These changes add the new init command!

Users can run `gh-templating init` to have the package create a dedicated folder for them. From there, they can get started on their magical PR templating adventure.

Users can also provide the desired arguments to the command and skip being prompted for both the path to the directory and the final directory name.

`gh-templating init path/to/directory PR_TEMPLATES`

Additionally, leaving the prompts blank will cause gh-templating to fall back to some convenient default values.

Finally, adding the flag -y to the empty command will skip both prompts and arguments and instead create a default directory at a default path, viz. `.github/templates`

`gh-templating init -y`