### PR TITLE
Add new flag to init command to allow segway into adding templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ This package also provides defaults. If you leave each prompt blank, gh-templati
 
 `gh-templating init -y`
 
+If you wish to segway immediately into adding templates from the package, you can add the `-i` flag to specify initial templates immediately after creating your directory:
+
+`gh-templating init -i`
+
 ## Create
 
 This package can also help you get started by generating new template files for you. These templates are generic versions set up by the package. These templates are a nice jumping off point for you to adjust to your project's needs. Alternatively, they might just be complete enough for you not to have to worry about making your own!

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 #! /usr/bin/env node
-import { use, init, create } from "./src/index.mjs";
+import { use, create, initAndCreate } from "./src/index.mjs";
 import { Command } from "commander";
 
 const program = new Command();
@@ -24,7 +24,13 @@ program
         "-y, --yes",
         "Skip prompts and arguments and immediately create the default directory - boolean - optional"
     )
-    .action((path, dirName, { yes }) => init(path, dirName, yes));
+    .option(
+        "-i, --initial",
+        "After initializing, segway into the create workflow to add templates - boolean - optional"
+    )
+    .action((path, dirName, { yes, initial }) =>
+        initAndCreate(path, dirName, yes, initial)
+    );
 
 program
     .command("create")

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
     "name": "gh-templating",
-    "version": "1.5.1",
+    "version": "1.6.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "gh-templating",
-            "version": "1.5.1",
+            "version": "1.6.0",
             "license": "ISC",
             "dependencies": {
                 "commander": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gh-templating",
-    "version": "1.5.1",
+    "version": "1.6.0",
     "description": "",
     "main": "index.js",
     "bin": {

--- a/src/create.mjs
+++ b/src/create.mjs
@@ -36,7 +36,7 @@ const writeSelectionToTemplatesFolder = (
         fs.mkdirSync(finalPath);
     }
 
-    if (chosenTemplates.length == 1 && title !== "") {
+    if (chosenTemplates.length == 1 && title) {
         const templateData = fs.readFileSync(
             path.join(pathToOwnTemplates, chosenTemplates[0])
         );
@@ -63,7 +63,6 @@ const writeSelectionToTemplatesFolder = (
 };
 
 export const create = (pathToTemplates, pathToReadTemplates, title, all) => {
-    console.log(pathToReadTemplates);
     if (all) {
         return writeSelectionToTemplatesFolder(
             pathToTemplates,

--- a/src/init.mjs
+++ b/src/init.mjs
@@ -2,6 +2,15 @@ import inquirer from "inquirer";
 import fs from "fs";
 import path from "path";
 import { DEFAULT_PATH, DEFAULT_DIRNAME } from "./util/global-constants.mjs";
+import { create } from "./create.mjs";
+
+export const initAndCreate = (pathToTemplates, directoryName, yes, initial) => {
+    init(pathToTemplates, directoryName, yes).then(() => {
+        if (initial) {
+            create(pathToTemplates);
+        }
+    });
+};
 
 export const init = async (pathToTemplates, directoryName, yes) => {
     if (yes) {


### PR DESCRIPTION
These changes add the exciting `-i` flag to the `init` command!

By passing this flag, you can immediately segway into adding templates right after creating your template directory. Currently, only the flags passed to the `init` command will actually be passed to this command. You cannot (yet) set flags for the `create` command here.