### PR TITLE
Add tests for other commands and core util fns

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,13 @@
-tests/
+node_modules
+ds_store
+coverage
+
+.prettierrc
+
 .github/
+.gitignore
+
+tests/
+jest.config.js
+
+.vscode

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Please refer to their [official documentation](https://cli.github.com/) for help
 
 To install, simply run:
 
-`npm install gh-templating`
+`npm install gh-templating --save-dev`
 
 You can also install this package globally by adding the `-g` flag. Note: `sudo` rights may be required.
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
     "name": "gh-templating",
-    "version": "1.6.1",
+    "version": "1.6.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "gh-templating",
-            "version": "1.6.1",
+            "version": "1.6.3",
             "license": "ISC",
             "dependencies": {
                 "commander": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gh-templating",
-    "version": "1.6.2",
+    "version": "1.6.3",
     "description": "",
     "main": "index.js",
     "bin": {

--- a/src/init.mjs
+++ b/src/init.mjs
@@ -5,25 +5,27 @@ import { DEFAULT_PATH, DEFAULT_DIRNAME } from "./util/global-constants.mjs";
 import { create } from "./create.mjs";
 
 export const initCommand = (pathToTemplates, directoryName, yes, initial) => {
-    init(pathToTemplates, directoryName, yes).then(() => {
+    return init(pathToTemplates, directoryName, yes).then(() => {
         if (initial) {
-            create(pathToTemplates);
+            return create(pathToTemplates);
         }
     });
 };
 
 export const init = async (pathToTemplates, directoryName, yes) => {
     if (yes) {
-        return makeDirectories(DEFAULT_PATH, DEFAULT_DIRNAME);
+        makeDirectories(DEFAULT_PATH, DEFAULT_DIRNAME);
+        return path.join(DEFAULT_PATH, DEFAULT_DIRNAME);
     }
 
     let dirPath = pathToTemplates;
     let dirName = directoryName;
 
     if (!pathToTemplates && !directoryName) {
-        const { path, dirName } = await resolveWithoutArgs();
+        const { dirPath, dirName } = await resolveWithoutArgs();
 
-        return makeDirectories(path, dirName);
+        makeDirectories(dirPath, dirName);
+        return path.join(dirPath, dirName);
     }
 
     if (!pathToTemplates) {
@@ -35,13 +37,14 @@ export const init = async (pathToTemplates, directoryName, yes) => {
     }
 
     makeDirectories(dirPath, dirName);
+    return path.join(dirPath, dirName);
 };
 
-const resolveWithoutArgs = async () => {
-    const path = await promptUserForPath();
+export const resolveWithoutArgs = async () => {
+    const dirPath = await promptUserForPath();
     const dirName = await promptUserForDirName();
 
-    return { path, dirName };
+    return { dirPath, dirName };
 };
 
 const promptUserForPath = async () => {

--- a/src/use.mjs
+++ b/src/use.mjs
@@ -11,7 +11,7 @@ export const useCommand = async (pathToTemplates, title) => {
 export const use = (pathToTemplates, title) => {
     const config = getConfig(pathToTemplates);
 
-    if (config.choices.length > 0) {
+    if (config && config.choices.length > 0) {
         return inquirer
             .prompt([
                 {
@@ -33,14 +33,18 @@ export const use = (pathToTemplates, title) => {
 
                 return `gh pr create --title "${prTitle}" --body-file ${pathToTemplate}`;
             })
-            .catch((error) => {
+            .catch((error) =>
                 console.error(
                     `Inquirer error: something went wrong processing your answer: ${error}`
-                );
-            });
+                )
+            );
     } else {
         console.error(
-            `Fatal error: no choices available. Expected at least one choice, but found none.`
+            `Fatal error: Expected at least one choice, but found none. ${
+                pathToTemplates
+                    ? `Looked in ${pathToTemplates}, .github/templates, and the .github ROOT folder`
+                    : "Looked in .github/templates and the .github ROOT folder."
+            }`
         );
     }
 };

--- a/src/util/template-choices.mjs
+++ b/src/util/template-choices.mjs
@@ -8,11 +8,9 @@ export const getMarkdownFilenames = (dirName) => {
 };
 
 export const getConfig = (pathToTemplates) => {
-    let config = { path: pathToTemplates, choices: [] };
-
     if (pathToTemplates) {
         try {
-            config = setConfig(pathToTemplates);
+            return setConfig(pathToTemplates);
         } catch (error) {
             console.error(
                 `Fatal error: no path provided or found to templates directory. Received ${pathToTemplates}`
@@ -26,25 +24,17 @@ export const getConfig = (pathToTemplates) => {
         {
             try {
                 const pathToSet = path.join(...`.github/templates`.split("/"));
-                config = setConfig(pathToSet);
+                return setConfig(pathToSet);
             } catch (error) {
                 console.error(
-                    `No templates found in: ROOT:.github/templates. Looking in ROOT:.github/`
+                    `No templates found in: ROOT:.github/templates. Looking in ROOT:.github/templates`
                 );
             }
         }
     } else {
-        try {
-            const pathToSet = ".github";
-            config = setConfig(pathToSet);
-        } catch (error) {
-            console.error(
-                `Fatal error: no templates found in codebase. Please specify a path to your templates.`
-            );
-        }
+        const pathToSet = ".github";
+        return setConfig(pathToSet);
     }
-
-    return config;
 };
 
 const setConfig = (pathToJoin) => {

--- a/tests/commands/create.test.js
+++ b/tests/commands/create.test.js
@@ -1,0 +1,88 @@
+import jest from "jest-mock";
+import fs from "fs";
+import path from "path";
+import inquirer from "inquirer";
+import {
+    DEFAULT_PATH,
+    DEFAULT_DIRNAME,
+} from "../../src/util/global-constants.mjs";
+import { initCommand } from "../../src/init.mjs";
+import { create } from "../../src/create.mjs";
+
+describe("The create command", () => {
+    const originalExistsSync = fs.existsSync;
+    const originalMkdirSync = fs.mkdirSync;
+    const originalReaddirSync = fs.readdirSync;
+    const originalReadFileSync = fs.readFileSync;
+    const originalWriteFileSync = fs.writeFileSync;
+    const originalInqPrompt = inquirer.prompt;
+
+    beforeEach(() => {
+        fs.existsSync = jest.fn().mockReturnValue(false);
+        fs.mkdirSync = jest.fn().mockReturnValue();
+        fs.readFileSync = jest.fn().mockReturnValue("");
+        fs.writeFileSync = jest.fn().mockReturnValue("");
+    });
+
+    it("should create a new file with a chosen title", async () => {
+        const createMessage = await create(
+            undefined,
+            undefined,
+            undefined,
+            true
+        );
+        expect(createMessage).toBe("Wrote to 6 locations");
+    });
+
+    it("should create a new file with a chosen title", async () => {
+        fs.readdirSync = jest.fn().mockReturnValue(["bugfix.md"]);
+        inquirer.prompt = jest
+            .fn()
+            .mockResolvedValue({ ["Templates"]: "bugfix.md" });
+        const createMessage = await create(
+            undefined,
+            undefined,
+            "my-new-template.md"
+        );
+        expect(createMessage).toBe(
+            "Wrote to one location with title: my-new-template.md"
+        );
+    });
+
+    it("should look in a different folder if supplied with the -o flag", async () => {
+        fs.readdirSync = jest.fn().mockReturnValue(["bugfix.md"]);
+        inquirer.prompt = jest
+            .fn()
+            .mockResolvedValue({ ["Templates"]: "bugfix.md" });
+        const createMessage = await create(
+            undefined,
+            "my-own-folder",
+            undefined
+        );
+        expect(createMessage).toBe("Wrote to 1 locations");
+    });
+
+    it("should call create after calling init when passed the -i flag", async () => {
+        fs.readdirSync = jest.fn().mockReturnValue(["bugfix.md"]);
+        inquirer.prompt = jest
+            .fn()
+            .mockResolvedValue({ ["Templates"]: "bugfix.md" });
+
+        const createMessage = await initCommand(
+            "rootfolder",
+            "templates",
+            undefined,
+            true
+        );
+        expect(createMessage).toBe("Wrote to 1 locations");
+    });
+
+    afterEach(() => {
+        fs.existsSync = originalExistsSync;
+        fs.mkdirSync = originalMkdirSync;
+        fs.readdirSync = originalReaddirSync;
+        fs.readFileSync = originalReadFileSync;
+        fs.writeFileSync = originalWriteFileSync;
+        inquirer.prompt = originalInqPrompt;
+    });
+});

--- a/tests/commands/init.test.js
+++ b/tests/commands/init.test.js
@@ -1,0 +1,61 @@
+import jest from "jest-mock";
+import fs from "fs";
+import path from "path";
+import inquirer from "inquirer";
+import {
+    DEFAULT_PATH,
+    DEFAULT_DIRNAME,
+} from "../../src/util/global-constants.mjs";
+import { init } from "../../src/init.mjs";
+
+describe("The init command", () => {
+    const originalExistsSync = fs.existsSync;
+    const originalMkdirSync = fs.mkdirSync;
+    const originalInqPrompt = inquirer.prompt;
+
+    beforeEach(() => {
+        fs.existsSync = jest.fn().mockReturnValue(false);
+        fs.mkdirSync = jest.fn().mockReturnValue();
+    });
+
+    it("should resolve properly without any args or flags", async () => {
+        inquirer.prompt = jest.fn().mockResolvedValue({
+            ["Path to new directory"]: "rootfolder",
+            ["Template directory name"]: "templating",
+        });
+
+        const pathAndDirname = await init();
+        expect(pathAndDirname).toBe("rootfolder/templating");
+    });
+
+    it("should resolve properly without a path argument", async () => {
+        inquirer.prompt = jest.fn().mockResolvedValue({
+            ["Path to new directory"]: "rootfolder",
+        });
+
+        const pathAndDirname = await init(undefined, "dir_templates");
+        expect(pathAndDirname).toBe("rootfolder/dir_templates");
+    });
+
+    it("should resolve properly without a dirname argument", async () => {
+        inquirer.prompt = jest.fn().mockResolvedValue({
+            ["Template directory name"]: "template_directory",
+        });
+
+        const pathAndDirname = await init("organization");
+        expect(pathAndDirname).toBe("organization/template_directory");
+    });
+
+    it("should skip prompts and set the default path when triggered with the -y option", async () => {
+        const pathAndDirname = init(undefined, undefined, true);
+        await expect(pathAndDirname).resolves.toBe(
+            path.join(DEFAULT_PATH, DEFAULT_DIRNAME)
+        );
+    });
+
+    afterEach(() => {
+        fs.existsSync = originalExistsSync;
+        fs.mkdirSync = originalMkdirSync;
+        inquirer.prompt = originalInqPrompt;
+    });
+});

--- a/tests/commands/use.test.js
+++ b/tests/commands/use.test.js
@@ -1,15 +1,13 @@
 import { use } from "../../src/use";
 import inquirer from "inquirer";
 import jest from "jest-mock";
-import child_process from "child_process";
 
 describe("The use function", () => {
-    const original = console.error;
-    const origExec = child_process.execSync;
+    const originalConsoleError = console.error;
+    const originalInqPrompt = inquirer.prompt;
 
     beforeEach(() => {
         console.error = jest.fn();
-        child_process.execSync = jest.fn();
     });
 
     it("should error when no choices are available", async () => {
@@ -17,7 +15,16 @@ describe("The use function", () => {
 
         await expect(use()).resolves;
         expect(console.error).toHaveBeenCalledWith(
-            "Fatal error: no choices available. Expected at least one choice, but found none."
+            "Fatal error: Expected at least one choice, but found none. Looked in .github/templates and the .github ROOT folder."
+        );
+    });
+
+    it("should error when no choices are available when directed to a directory with no templates", async () => {
+        inquirer.prompt = jest.fn().mockResolvedValue();
+
+        await expect(use(".github/templates/no-dir")).resolves;
+        expect(console.error).toHaveBeenCalledWith(
+            "Fatal error: Expected at least one choice, but found none. Looked in .github/templates/no-dir, .github/templates, and the .github ROOT folder"
         );
     });
 
@@ -52,7 +59,7 @@ describe("The use function", () => {
     });
 
     afterEach(() => {
-        console.error = original;
-        child_process.execSync = origExec;
+        console.error = originalConsoleError;
+        inquirer.prompt = originalInqPrompt;
     });
 });

--- a/tests/util/template-choices.test.js
+++ b/tests/util/template-choices.test.js
@@ -1,0 +1,59 @@
+import { getConfig } from "../../src/util/template-choices.mjs";
+import { TEMPLATES } from "../../templates/index.mjs";
+import jest from "jest-mock";
+import fs from "fs";
+import { executeCommand } from "../../src/util/execute-command.mjs";
+
+describe("template-choices helpers", () => {
+    describe("getConfig", () => {
+        const originalConsoleError = console.error;
+        const originalExistsSync = fs.existsSync;
+        const originalReaddirSync = fs.readdirSync;
+
+        beforeEach(() => {
+            console.error = jest.fn();
+        });
+
+        it("should correctly set all template files in the choices array when looking inside the templates folder", () => {
+            const path = "templates";
+            const expectedConfig = { path, choices: TEMPLATES };
+            const config = getConfig(path);
+            expect(config).toEqual(expectedConfig);
+        });
+
+        it("should set choices as empty if it finds nothing inside .github folder", () => {
+            const expectedConfig = { path: ".github", choices: [] };
+
+            const config = getConfig();
+            expect(config).toEqual(expectedConfig);
+        });
+
+        it("should find templates when looking in existing .github/templates directory", () => {
+            fs.existsSync = jest.fn().mockReturnValue(true);
+            fs.readdirSync = jest.fn().mockReturnValue(["bugfix.md"]);
+
+            const expectedConfig = {
+                path: ".github/templates",
+                choices: ["bugfix.md"],
+            };
+
+            const config = getConfig();
+            expect(config).toEqual(expectedConfig);
+        });
+
+        it("should log error when looking for templates in existing .github/templates directory", () => {
+            fs.existsSync = jest.fn().mockReturnValue(true);
+
+            const config = getConfig();
+            expect(console.error).toHaveBeenCalledWith(
+                "No templates found in: ROOT:.github/templates. Looking in ROOT:.github/templates"
+            );
+        });
+
+        afterEach(() => {
+            console.error = originalConsoleError;
+            fs.existsSync = originalExistsSync;
+            fs.readdirSync = originalReaddirSync;
+        });
+    });
+});


### PR DESCRIPTION
These changes add tests to the `init` and `create` commands, as well as to the template-choices util functions.

Bumping patch version to reflect minor changes in the code. But nothing new in this release!