### PR TITLE
Update init command to accept all options applicable to create. Updat…

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ If you wish to segway immediately into adding templates from the package, you ca
 
 `gh-templating init -i`
 
+All options that apply to the `create` command will also work when combined with this flag! This way you can e.g. figure out the final destination for your templates by answering the prompts in `init` and quickly add all the available templates to your directory:
+
+`gh-templating init -y -a`
+
 ## Create
 
 This package can also help you get started by generating new template files for you. These templates are generic versions set up by the package. These templates are a nice jumping off point for you to adjust to your project's needs. Alternatively, they might just be complete enough for you not to have to worry about making your own!

--- a/index.js
+++ b/index.js
@@ -28,13 +28,27 @@ program
         "-i, --initial",
         "After initializing, segway into the create workflow to add templates - boolean - optional"
     )
-    .action((path, dirName, { yes, initial }) =>
-        initCommand(path, dirName, yes, initial)
+    .option(
+        "-o, --own <string>",
+        "Path to your own templates - string - optional",
+        ""
+    )
+    .option(
+        "-t, --title <string>",
+        "Title of your new PR template. Only works when selecting one template - string - optional",
+        ""
+    )
+    .option(
+        "-a, --all",
+        "Skip prompts and arguments and immediately add all templates - boolean - optional"
+    )
+    .action((path, dirName, { yes, initial, own, title, all }) =>
+        initCommand(path, dirName, yes, initial, own, title, all)
     );
 
 program
     .command("create")
-    .description("Initialize a directory for your templates")
+    .description("Add a template to your codebase")
     .argument("[path]", "Path to your new directory - string - optional")
     .option(
         "-o, --own <string>",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
     "name": "gh-templating",
-    "version": "1.6.3",
+    "version": "1.6.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "gh-templating",
-            "version": "1.6.3",
+            "version": "1.6.4",
             "license": "ISC",
             "dependencies": {
                 "commander": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gh-templating",
-    "version": "1.6.3",
+    "version": "1.6.4",
     "description": "",
     "main": "index.js",
     "bin": {

--- a/src/create.mjs
+++ b/src/create.mjs
@@ -51,7 +51,10 @@ const writeSelectionToTemplatesFolder = (
         const fileName = path.join(finalPath, finalTitle);
 
         fs.writeFileSync(fileName, templateData);
-        return `Wrote to one location with title: ${title}`;
+
+        const message = `Wrote ${title} to ${finalPath}, sourced from ${pathToOwnTemplates}`;
+        console.info(message);
+        return message;
     }
 
     for (let index = 0; index < finalChosenTemplates.length; index++) {
@@ -66,7 +69,9 @@ const writeSelectionToTemplatesFolder = (
         fs.writeFileSync(fileName, templateData);
     }
 
-    return `Wrote to ${finalChosenTemplates.length} locations`;
+    const message = `Wrote ${finalChosenTemplates} to ${finalPath}, sourced from ${pathToOwnTemplates}`;
+    console.info(message);
+    return message;
 };
 
 export const create = (pathToTemplates, pathToReadTemplates, title, all) => {

--- a/src/init.mjs
+++ b/src/init.mjs
@@ -4,10 +4,18 @@ import path from "path";
 import { DEFAULT_PATH, DEFAULT_DIRNAME } from "./util/global-constants.mjs";
 import { create } from "./create.mjs";
 
-export const initCommand = (pathToTemplates, directoryName, yes, initial) => {
+export const initCommand = (
+    pathToTemplates,
+    directoryName,
+    yes,
+    initial,
+    own,
+    title,
+    all
+) => {
     return init(pathToTemplates, directoryName, yes).then(() => {
         if (initial) {
-            return create(pathToTemplates);
+            return create(pathToTemplates, own, title, all);
         }
     });
 };

--- a/tests/commands/create.test.js
+++ b/tests/commands/create.test.js
@@ -1,11 +1,6 @@
 import jest from "jest-mock";
 import fs from "fs";
-import path from "path";
 import inquirer from "inquirer";
-import {
-    DEFAULT_PATH,
-    DEFAULT_DIRNAME,
-} from "../../src/util/global-constants.mjs";
 import { initCommand } from "../../src/init.mjs";
 import { create } from "../../src/create.mjs";
 
@@ -15,6 +10,7 @@ describe("The create command", () => {
     const originalReaddirSync = fs.readdirSync;
     const originalReadFileSync = fs.readFileSync;
     const originalWriteFileSync = fs.writeFileSync;
+    const originalConsoleInfo = console.info;
     const originalInqPrompt = inquirer.prompt;
 
     beforeEach(() => {
@@ -22,16 +18,19 @@ describe("The create command", () => {
         fs.mkdirSync = jest.fn().mockReturnValue();
         fs.readFileSync = jest.fn().mockReturnValue("");
         fs.writeFileSync = jest.fn().mockReturnValue("");
+        console.info = jest.fn();
     });
 
-    it("should create a new file with a chosen title", async () => {
+    it("should add all templates when supplied with the -a flag", async () => {
         const createMessage = await create(
             undefined,
             undefined,
             undefined,
             true
         );
-        expect(createMessage).toBe("Wrote to 6 locations");
+        expect(createMessage).toBe(
+            "Wrote backport_template.md,bugfix_template.md,empty_template.md,feature_template.md,hotfix_template.md,release_template.md to .github/templates, sourced from /Users/jorgevandesompel/Documents/gh-templating/templates"
+        );
     });
 
     it("should create a new file with a chosen title", async () => {
@@ -45,7 +44,7 @@ describe("The create command", () => {
             "my-new-template.md"
         );
         expect(createMessage).toBe(
-            "Wrote to one location with title: my-new-template.md"
+            "Wrote my-new-template.md to .github/templates, sourced from /Users/jorgevandesompel/Documents/gh-templating/templates"
         );
     });
 
@@ -59,7 +58,9 @@ describe("The create command", () => {
             "my-own-folder",
             undefined
         );
-        expect(createMessage).toBe("Wrote to 1 locations");
+        expect(createMessage).toBe(
+            "Wrote bugfix.md to .github/templates, sourced from my-own-folder"
+        );
     });
 
     it("should call create after calling init when passed the -i flag", async () => {
@@ -74,7 +75,9 @@ describe("The create command", () => {
             undefined,
             true
         );
-        expect(createMessage).toBe("Wrote to 1 locations");
+        expect(createMessage).toBe(
+            "Wrote bugfix.md to rootfolder, sourced from /Users/jorgevandesompel/Documents/gh-templating/templates"
+        );
     });
 
     afterEach(() => {
@@ -84,5 +87,6 @@ describe("The create command", () => {
         fs.readFileSync = originalReadFileSync;
         fs.writeFileSync = originalWriteFileSync;
         inquirer.prompt = originalInqPrompt;
+        console.info = originalConsoleInfo;
     });
 });

--- a/tests/commands/create.test.js
+++ b/tests/commands/create.test.js
@@ -28,8 +28,8 @@ describe("The create command", () => {
             undefined,
             true
         );
-        expect(createMessage).toBe(
-            "Wrote backport_template.md,bugfix_template.md,empty_template.md,feature_template.md,hotfix_template.md,release_template.md to .github/templates, sourced from /Users/jorgevandesompel/Documents/gh-templating/templates"
+        expect(createMessage).toContain(
+            "Wrote backport_template.md,bugfix_template.md,empty_template.md,feature_template.md,hotfix_template.md,release_template.md to .github/templates"
         );
     });
 
@@ -43,8 +43,8 @@ describe("The create command", () => {
             undefined,
             "my-new-template.md"
         );
-        expect(createMessage).toBe(
-            "Wrote my-new-template.md to .github/templates, sourced from /Users/jorgevandesompel/Documents/gh-templating/templates"
+        expect(createMessage).toContain(
+            "Wrote my-new-template.md to .github/templates"
         );
     });
 
@@ -75,9 +75,7 @@ describe("The create command", () => {
             undefined,
             true
         );
-        expect(createMessage).toBe(
-            "Wrote bugfix.md to rootfolder, sourced from /Users/jorgevandesompel/Documents/gh-templating/templates"
-        );
+        expect(createMessage).toContain("Wrote bugfix.md to rootfolder");
     });
 
     afterEach(() => {


### PR DESCRIPTION
Update init command to accept all options applicable to create. 
Update logging in create.
Update readme.

These changes allow users to pass all the `create` flags to the `init` command as well, allowing for a smooth transition from `init` to `create`. The readme has been updated to reflect this change.

Updated logging to be clearer when creating templates.